### PR TITLE
#3 [Feat] 카카오 연동 회원 로그아웃 및 탈퇴 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 HELP.md
+.DS_Store
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/src/main/java/dev/plant/backend/domain/oauth/controller/KakaoAuthController.java
+++ b/src/main/java/dev/plant/backend/domain/oauth/controller/KakaoAuthController.java
@@ -1,10 +1,13 @@
 package dev.plant.backend.domain.oauth.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.plant.backend.domain.oauth.service.KakaoService;
 import dev.plant.backend.domain.oauth.dto.KakaoUserInfoResponseDto;
 import dev.plant.backend.domain.user.dto.LoginResponseDto;
 import dev.plant.backend.domain.user.service.UserService;
 import dev.plant.backend.global.response.ApiResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,10 +15,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -58,6 +58,7 @@ public class KakaoAuthController {
         LoginResponseDto loginResponse = userService.loginWithKakao(userInfo);
 
         session.setAttribute("kakaoId", userInfo.getId());
+        session.setAttribute("accessToken", accessToken);
 
         String message = loginResponse.isNewUser()
                 ? "신규 유저입니다. 잔액 정보를 먼저 입력해주세요."
@@ -67,5 +68,66 @@ public class KakaoAuthController {
 
         return ResponseEntity.ok(ApiResponse.of(status.value(), message, loginResponse));
     }
+
+    @GetMapping("/logout")
+    public ResponseEntity<Void> logout(HttpSession session, HttpServletResponse response) {
+        String accessToken = (String) session.getAttribute("accessToken");
+        if (accessToken != null && !accessToken.isEmpty()) {
+            try {
+                kakaoService.kakaoDisconnect(accessToken); // 카카오 서버 세션 무효화
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("카카오 로그아웃 실패", e);
+            }
+        } else {
+            log.warn("accessToken 없음: 카카오 로그아웃은 수행되지 않음");
+        }
+
+        // 세션 무효화
+        session.invalidate();
+
+        // accessToken 쿠키 삭제
+        Cookie accessTokenCookie = new Cookie("accessToken", null);
+        accessTokenCookie.setMaxAge(0);
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setHttpOnly(true);
+        response.addCookie(accessTokenCookie);
+
+        // JSESSIONID 쿠키 삭제 - 매우 중요
+        Cookie jsessionCookie = new Cookie("JSESSIONID", null);
+        jsessionCookie.setMaxAge(0);
+        jsessionCookie.setPath("/");
+        response.addCookie(jsessionCookie);
+
+        return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<Void> delete(HttpSession session, HttpServletResponse response) {
+        try {
+            if (session == null) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+            }
+            userService.withdraw(session);
+
+            // accessToken 쿠키 삭제
+            Cookie accessTokenCookie = new Cookie("accessToken", null);
+            accessTokenCookie.setMaxAge(0);
+            accessTokenCookie.setPath("/");
+            accessTokenCookie.setHttpOnly(true);
+            response.addCookie(accessTokenCookie);
+
+            // JSESSIONID 쿠키 삭제
+            Cookie jsessionCookie = new Cookie("JSESSIONID", null);
+            jsessionCookie.setMaxAge(0);
+            jsessionCookie.setPath("/");
+            response.addCookie(jsessionCookie);
+
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            // 기타 서버 에러
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
 
 }

--- a/src/main/java/dev/plant/backend/domain/oauth/controller/KakaoAuthController.java
+++ b/src/main/java/dev/plant/backend/domain/oauth/controller/KakaoAuthController.java
@@ -5,16 +5,14 @@ import dev.plant.backend.domain.oauth.service.KakaoService;
 import dev.plant.backend.domain.oauth.dto.KakaoUserInfoResponseDto;
 import dev.plant.backend.domain.user.dto.LoginResponseDto;
 import dev.plant.backend.domain.user.service.UserService;
+import dev.plant.backend.global.ErrorCode;
+import dev.plant.backend.global.exception.ApiException;
 import dev.plant.backend.global.response.ApiResponse;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
@@ -70,7 +68,7 @@ public class KakaoAuthController {
     }
 
     @GetMapping("/logout")
-    public ResponseEntity<Void> logout(HttpSession session, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Void>> logout(HttpSession session, HttpServletResponse response) {
         String accessToken = (String) session.getAttribute("accessToken");
         if (accessToken != null && !accessToken.isEmpty()) {
             try {
@@ -82,52 +80,46 @@ public class KakaoAuthController {
             log.warn("accessToken 없음: 카카오 로그아웃은 수행되지 않음");
         }
 
-        // 세션 무효화
         session.invalidate();
+        deleteAccessCookie(response, "accessToken");
+        deleteJsessionCookie(response, "JSESSIONID");
 
-        // accessToken 쿠키 삭제
-        Cookie accessTokenCookie = new Cookie("accessToken", null);
+        return ResponseEntity.ok(ApiResponse.of(200, "로그아웃이 완료되었습니다.", null));
+    }
+
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<ApiResponse<Void>> delete(HttpSession session, HttpServletResponse response) {
+        try {
+            if (session == null || session.getAttribute("kakaoId") == null) {
+                        throw  new ApiException((ErrorCode.NOT_FOUND_RESOURCE));
+            }
+            userService.withdraw(session);
+
+            deleteAccessCookie(response, "accessToken");
+
+            deleteJsessionCookie(response, "JSESSIONID");
+
+            return ResponseEntity.ok(ApiResponse.of(200, "회원 탈퇴가 완료되었습니다", null));
+
+        } catch (Exception e) {
+            throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+    //Access Cookie 삭제
+    private void deleteAccessCookie(HttpServletResponse response, String cookieName) {
+        Cookie accessTokenCookie = new Cookie(cookieName, null);
         accessTokenCookie.setMaxAge(0);
         accessTokenCookie.setPath("/");
         accessTokenCookie.setHttpOnly(true);
         response.addCookie(accessTokenCookie);
-
-        // JSESSIONID 쿠키 삭제 - 매우 중요
-        Cookie jsessionCookie = new Cookie("JSESSIONID", null);
+    }
+    // JSESSIONID 쿠키 삭제
+    private void deleteJsessionCookie(HttpServletResponse response, String jsessionId) {
+        Cookie jsessionCookie = new Cookie(jsessionId, null);
         jsessionCookie.setMaxAge(0);
         jsessionCookie.setPath("/");
         response.addCookie(jsessionCookie);
-
-        return ResponseEntity.noContent().build(); // 204 No Content
     }
-
-    @DeleteMapping("/delete")
-    public ResponseEntity<Void> delete(HttpSession session, HttpServletResponse response) {
-        try {
-            if (session == null) {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-            }
-            userService.withdraw(session);
-
-            // accessToken 쿠키 삭제
-            Cookie accessTokenCookie = new Cookie("accessToken", null);
-            accessTokenCookie.setMaxAge(0);
-            accessTokenCookie.setPath("/");
-            accessTokenCookie.setHttpOnly(true);
-            response.addCookie(accessTokenCookie);
-
-            // JSESSIONID 쿠키 삭제
-            Cookie jsessionCookie = new Cookie("JSESSIONID", null);
-            jsessionCookie.setMaxAge(0);
-            jsessionCookie.setPath("/");
-            response.addCookie(jsessionCookie);
-
-            return ResponseEntity.noContent().build();
-        } catch (Exception e) {
-            // 기타 서버 에러
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        }
-    }
-
 
 }

--- a/src/main/java/dev/plant/backend/domain/oauth/service/KakaoService.java
+++ b/src/main/java/dev/plant/backend/domain/oauth/service/KakaoService.java
@@ -1,13 +1,20 @@
 package dev.plant.backend.domain.oauth.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.plant.backend.domain.oauth.dto.KakaoTokenResponseDto;
 import dev.plant.backend.domain.oauth.dto.KakaoUserInfoResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.Objects;
@@ -60,6 +67,35 @@ public class KakaoService {
         log.info("[KakaoService] ProfileImageUrl = {}", userInfo.getKakaoAccount().getProfile().getProfileImageUrl());
 
         return userInfo;
+    }
+
+    //로그아웃
+    public void kakaoDisconnect(String accessToken) throws JsonProcessingException {
+        String response = WebClient.create("https://kapi.kakao.com")
+                .post()
+                .uri("/v1/user/logout")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        log.info("[KakaoService] logout response = {}", response);
+    }
+
+    //회원 탈퇴
+    public void unlinkKakaoAccount(String accessToken) {
+        WebClient.create("https://kapi.kakao.com")
+                .post()
+                .uri("/v1/user/unlink")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(String.class)
+                .doOnSuccess(response -> log.info("[KakaoService] unlink response = {}", response))
+                .doOnError(e -> {
+                    throw new RuntimeException("카카오 계정 연결 실패", e); //카카오 계정 연결 실패시 에러
+                })
+                .block();
     }
 
 }

--- a/src/main/java/dev/plant/backend/domain/oauth/service/KakaoService.java
+++ b/src/main/java/dev/plant/backend/domain/oauth/service/KakaoService.java
@@ -1,20 +1,12 @@
 package dev.plant.backend.domain.oauth.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.plant.backend.domain.oauth.dto.KakaoTokenResponseDto;
-import dev.plant.backend.domain.oauth.dto.KakaoUserInfoResponseDto;
+import dev.plant.backend.domain.oauth.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.Objects;

--- a/src/main/java/dev/plant/backend/global/ErrorCode.java
+++ b/src/main/java/dev/plant/backend/global/ErrorCode.java
@@ -1,0 +1,15 @@
+package dev.plant.backend.global;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    INTERNAL_SERVER_ERROR("정의되지 않은 에러가 발생했습니다.", 500),
+    BAD_REQUEST("잘못된 요청입니다.", 400),
+    NOT_FOUND_RESOURCE("존재하지 않는 리소스입니다.", 404),
+    CONFLICT_ERROR("중복된 값입니다.", 409);
+
+    private final String message;
+    private final int status;
+}

--- a/src/main/java/dev/plant/backend/global/ErrorResponse.java
+++ b/src/main/java/dev/plant/backend/global/ErrorResponse.java
@@ -1,0 +1,58 @@
+package dev.plant.backend.global;
+
+import lombok.Getter;
+import org.springframework.validation.*;
+import java.util.*;
+
+@Getter
+public class ErrorResponse {
+    private String message;
+    private int status;
+    private List<FieldError> errors;
+
+    private ErrorResponse(ErrorCode errorCode) {
+        this.message = errorCode.getMessage();
+        this.status = errorCode.getStatus();
+        this.errors = new ArrayList<>();
+    }
+    private ErrorResponse(ErrorCode errorCode, List<FieldError> errors) {
+        this.message = errorCode.getMessage();
+        this.status = errorCode.getStatus();
+        this.errors = errors;
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, BindingResult bindingResult) {
+        return new ErrorResponse(errorCode, FieldError.of(bindingResult));
+    }
+    @Getter
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+        protected FieldError() {
+        }
+        private FieldError(final String field, final String value, final String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+        private static List<FieldError> of(final BindingResult bindingResult) {
+            List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+            return fieldErrors
+                    .stream()
+                    .map(filedError -> new FieldError(
+                            filedError.getField(),
+                            filedError.getRejectedValue() == null ? "" : filedError
+                                    .getRejectedValue()
+                                    .toString(),
+                            filedError.getDefaultMessage()
+                    ))
+                    .toList();
+        }
+    }
+
+}

--- a/src/main/java/dev/plant/backend/global/GlobalExceptionHandler.java
+++ b/src/main/java/dev/plant/backend/global/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package dev.plant.backend.global;
+
+import dev.plant.backend.global.exception.ApiException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+        log.error("handelException", exception);
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+    //400 Bad Request
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleApiException(ApiException exception) {
+        ErrorResponse errorResponse = ErrorResponse.of(exception.getErrorCode());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+
+}

--- a/src/main/java/dev/plant/backend/global/exception/ApiException.java
+++ b/src/main/java/dev/plant/backend/global/exception/ApiException.java
@@ -1,0 +1,17 @@
+package dev.plant.backend.global.exception;
+
+import dev.plant.backend.global.ErrorCode;
+
+public class ApiException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+}


### PR DESCRIPTION
##  카카오 소셜 로그아웃 및 회원 탈퇴 기능 구현

### 개요  
> 카카오 소셜 로그인을 사용하는 사용자의 로그아웃 및 회원 탈퇴 기능을 구현 /  로그아웃 시 세션과 쿠키를  삭제하고, 탈퇴 시 유저 정보를 DB에서 물리적으로 삭제

###  구현 내용  
- **카카오 소셜 로그인 유저 로그아웃 처리**
  - `accessToken`, `JSESSIONID` 쿠키 삭제
  - 로그아웃 성공 시 응답 메시지 반환

- **회원 탈퇴 처리**
  - Kakao unlink API 호출로 카카오 서버 측 세션 해제
  - 세션 존재 및 유저 검증 로직 추가
  - 서비스 계층에서 사용자 물리 삭제 처리
  - 쿠키 제거 및 응답 메시지 반환

- **API 응답 처리 통일**
  - `ApiResponse` 포맷으로 성공 메시지 및 상태코드 제공
