### PR TITLE
#6 [Feat] 엔티티 연관관계 및 편의 메서드 설계

### DIFF
--- a/src/main/java/dev/plant/backend/domain/monthlyReport/domain/MonthlyReport.java
+++ b/src/main/java/dev/plant/backend/domain/monthlyReport/domain/MonthlyReport.java
@@ -1,0 +1,50 @@
+package dev.plant.backend.domain.monthlyReport.domain;
+
+import dev.plant.backend.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "monthly_reports")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MonthlyReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id", nullable=false)
+    private User user;
+
+    //default 0으로 설정
+
+    @Column(nullable = false)
+    private Integer total_income = 0;
+
+    @Column(nullable = false)
+    private Integer total_expense = 0;
+
+    @Column(nullable = false)
+    private Integer total_balance = 0;
+
+    @Column(nullable = false)
+    private Long date;
+
+    @Builder
+    public MonthlyReport(Integer total_income, Integer total_expense, Integer total_balance, Long date) {
+        this.total_income = total_income;
+        this.total_expense = total_expense;
+        this.total_balance = total_balance;
+        this.date = date;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+        if (user != null && !user.getMonthlyReports().contains(this)) {
+            user.getMonthlyReports().add(this);
+        }
+    }
+}

--- a/src/main/java/dev/plant/backend/domain/transaction/domain/Transaction.java
+++ b/src/main/java/dev/plant/backend/domain/transaction/domain/Transaction.java
@@ -1,0 +1,62 @@
+package dev.plant.backend.domain.transaction.domain;
+
+import dev.plant.backend.domain.transaction.model.Category;
+import dev.plant.backend.domain.transaction.model.Type;
+import dev.plant.backend.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "transactions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Transaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Type type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private Integer amount = 0;
+
+    @Column(length = 255)
+    private String memo;
+
+    @Column(nullable = false)
+    private Long date;
+
+    @Builder
+    public Transaction(Type type, Category category, String title, Integer amount, String memo, Long date) {
+        this.type = type;
+        this.category = category;
+        this.title = title;
+        this.amount = amount;
+        this.memo = memo;
+        this.date = date;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+        if (user != null && !user.getTransactions().contains(this)) {
+            user.getTransactions().add(this);
+        }
+    }
+
+
+}

--- a/src/main/java/dev/plant/backend/domain/transaction/model/Category.java
+++ b/src/main/java/dev/plant/backend/domain/transaction/model/Category.java
@@ -1,0 +1,13 @@
+package dev.plant.backend.domain.transaction.model;
+
+public enum Category {
+    TRANSFER,       // 이체
+    EDUCATION,      // 교육
+    BEAUTY,         // 미용
+    HOBBY,          // 취미
+    TRANSPORT,      // 교통
+    HOUSING,        // 주거
+    COMMUNICATION,  // 통신
+    FOOD,           // 음식
+    ETC             // 기타
+}

--- a/src/main/java/dev/plant/backend/domain/transaction/model/Type.java
+++ b/src/main/java/dev/plant/backend/domain/transaction/model/Type.java
@@ -1,0 +1,6 @@
+package dev.plant.backend.domain.transaction.model;
+
+public enum Type {
+    INCOME,     // 수입
+    EXPENSE     // 지출
+}

--- a/src/main/java/dev/plant/backend/domain/user/domain/User.java
+++ b/src/main/java/dev/plant/backend/domain/user/domain/User.java
@@ -1,14 +1,18 @@
 package dev.plant.backend.domain.user.domain;
 
+import dev.plant.backend.domain.monthlyReport.domain.MonthlyReport;
+import dev.plant.backend.domain.transaction.domain.Transaction;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
 public class User {
 
     @Id
@@ -25,6 +29,38 @@ public class User {
     private String profileImage;
 
     @Column(nullable = true)
-    private Integer accountBalance;
+    private Integer accountBalance = 0;
+
+    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Transaction> transactions = new ArrayList<>(); // 거래내역을 삭제할경우, 사용자의 정보에 거래내역에서도 같이 삭제되게
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MonthlyReport> monthlyReports = new ArrayList<>();
+
+    @Builder
+    public User(Long kakaoId, String nickname, String profileImage, Integer accountBalance){
+        this.kakaoId = kakaoId;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.accountBalance = accountBalance;
+    }
+
+
+    //User -> Transaction 편의 매서드
+    public void addTransaction(Transaction transaction) {
+        this.transactions.add(transaction);
+        if(transaction.getUser() != this) {
+            transaction.setUser(this);
+        }
+    }
+
+    // User -> MonthlyReport 편의 매서드
+    public void addMonthlyReport(MonthlyReport monthlyReport) {
+        this.monthlyReports.add(monthlyReport);
+        if (monthlyReport.getUser() != this) {
+            monthlyReport.setUser(this);
+        }
+    }
+
 
 }


### PR DESCRIPTION
### 전체 도메인 엔티티 구조 설계
> 서비스 전반의 핵심 도메인인 Users, Transaction, MonthlyReport 엔티티 구조를 설계하고, 연관관계를 정의
### 주요 변경 사항
- `User` 엔티티: 사용자 기본 정보(kakaoId, nickname, profileImage) 및 현재 잔액(accountBalance) 관리
- `Transaction` 엔티티: 사용자 수입/지출 내역 저장 (금액, 카테고리, 메모, 날짜 포함)
- `MonthlyReport` 엔티티: 월별 수입/지출/잔액 요약 데이터 저장
### 설계 구조 
- 모든 도메인은 `User`를 기준으로 설계되며, `user_id`를 외래 키로 설정하여 사용자 중심의 데이터 구조 구성
- `User` ↔ `Transaction`, `User` ↔ `MonthlyReport` 간 양방향 연관관계 설정
- 각 엔티티에 연관관계 편의 메서드(`addTransaction`, `addMonthlyReport`) 구현
- Builder 패턴 사용 시 연관관계는 외부에서 명시적으로 설정하여 안정성 확보
- `CascadeType.ALL` 및 `orphanRemoval=true` 설정으로 관련 데이터 자동 제거

