### PR TITLE
#8 [Feat] 사용자 계좌 잔액 입력 및 수정 기능 구현

### DIFF
--- a/src/main/java/dev/plant/backend/domain/oauth/controller/KakaoAuthController.java
+++ b/src/main/java/dev/plant/backend/domain/oauth/controller/KakaoAuthController.java
@@ -84,7 +84,7 @@ public class KakaoAuthController {
         deleteAccessCookie(response, "accessToken");
         deleteJsessionCookie(response, "JSESSIONID");
 
-        return ResponseEntity.ok(ApiResponse.of(200, "로그아웃이 완료되었습니다.", null));
+        return ResponseEntity.ok(ApiResponse.ok( "로그아웃이 완료되었습니다.", null));
     }
 
 
@@ -100,7 +100,7 @@ public class KakaoAuthController {
 
             deleteJsessionCookie(response, "JSESSIONID");
 
-            return ResponseEntity.ok(ApiResponse.of(200, "회원 탈퇴가 완료되었습니다", null));
+            return ResponseEntity.ok(ApiResponse.ok("회원 탈퇴가 완료되었습니다", null));
 
         } catch (Exception e) {
             throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);

--- a/src/main/java/dev/plant/backend/domain/user/controller/UserController.java
+++ b/src/main/java/dev/plant/backend/domain/user/controller/UserController.java
@@ -1,0 +1,26 @@
+package dev.plant.backend.domain.user.controller;
+
+import dev.plant.backend.domain.user.dto.*;
+import dev.plant.backend.domain.user.service.UserService;
+import dev.plant.backend.global.response.ApiResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(value = "/api/users",produces = "application/json; charset=UTF8")
+@RequiredArgsConstructor
+@Slf4j
+public class UserController {
+
+    private final UserService userService;
+
+    @PatchMapping("/balance")
+    public ResponseEntity<ApiResponse<UserBalanceResponse>> updateBalance(HttpSession session, @Valid @RequestBody UserBalanceRequest userBalanceRequest) {
+        UserBalanceResponse userBalanceResponse = userService.changeAccountBalance(session, userBalanceRequest);
+        return ResponseEntity.ok(ApiResponse.ok("총 잔액이 성공적으로 설정되었습니다",userBalanceResponse));
+    }
+}

--- a/src/main/java/dev/plant/backend/domain/user/controller/UserController.java
+++ b/src/main/java/dev/plant/backend/domain/user/controller/UserController.java
@@ -21,6 +21,6 @@ public class UserController {
     @PatchMapping("/balance")
     public ResponseEntity<ApiResponse<UserBalanceResponse>> updateBalance(HttpSession session, @Valid @RequestBody UserBalanceRequest userBalanceRequest) {
         UserBalanceResponse userBalanceResponse = userService.changeAccountBalance(session, userBalanceRequest);
-        return ResponseEntity.ok(ApiResponse.ok("총 잔액이 성공적으로 설정되었습니다",userBalanceResponse));
+        return ResponseEntity.ok(ApiResponse.ok("총 잔액이 성공적으로 설정되었습니다", userBalanceResponse));
     }
 }

--- a/src/main/java/dev/plant/backend/domain/user/domain/User.java
+++ b/src/main/java/dev/plant/backend/domain/user/domain/User.java
@@ -28,7 +28,7 @@ public class User {
     @Column(nullable = false)
     private String profileImage;
 
-    @Column(nullable = true)
+    @Column(nullable = false)
     private Integer accountBalance = 0;
 
     @OneToMany(mappedBy = "user",cascade = CascadeType.ALL, orphanRemoval = true)
@@ -60,6 +60,11 @@ public class User {
         if (monthlyReport.getUser() != this) {
             monthlyReport.setUser(this);
         }
+    }
+
+    //잔액 입력
+    public void updateAccountBalance(Integer newAccountBalance) {
+        this.accountBalance = newAccountBalance != null ? newAccountBalance : 0; //사용자가 Null로 보내면 0으로 처리
     }
 
 

--- a/src/main/java/dev/plant/backend/domain/user/dto/UserBalanceRequest.java
+++ b/src/main/java/dev/plant/backend/domain/user/dto/UserBalanceRequest.java
@@ -1,0 +1,11 @@
+package dev.plant.backend.domain.user.dto;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder
+public class UserBalanceRequest {
+    private Integer accountBalance;
+}

--- a/src/main/java/dev/plant/backend/domain/user/dto/UserBalanceResponse.java
+++ b/src/main/java/dev/plant/backend/domain/user/dto/UserBalanceResponse.java
@@ -1,0 +1,9 @@
+package dev.plant.backend.domain.user.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+public class UserBalanceResponse {
+    private Integer accountBalance;
+}

--- a/src/main/java/dev/plant/backend/domain/user/exception/NotFoundUserException.java
+++ b/src/main/java/dev/plant/backend/domain/user/exception/NotFoundUserException.java
@@ -1,0 +1,10 @@
+package dev.plant.backend.domain.user.exception;
+
+import dev.plant.backend.global.ErrorCode;
+import dev.plant.backend.global.exception.BusinessException;
+
+public class NotFoundUserException extends BusinessException {
+    public NotFoundUserException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/dev/plant/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/dev/plant/backend/domain/user/repository/UserRepository.java
@@ -2,9 +2,10 @@ package dev.plant.backend.domain.user.repository;
 
 import dev.plant.backend.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByKakaoId(Long kakaoId);

--- a/src/main/java/dev/plant/backend/domain/user/service/UserService.java
+++ b/src/main/java/dev/plant/backend/domain/user/service/UserService.java
@@ -3,12 +3,15 @@ package dev.plant.backend.domain.user.service;
 import dev.plant.backend.domain.oauth.service.KakaoService;
 import dev.plant.backend.domain.user.domain.User;
 import dev.plant.backend.domain.oauth.dto.KakaoUserInfoResponseDto;
-import dev.plant.backend.domain.user.dto.LoginResponseDto;
+import dev.plant.backend.domain.user.dto.*;
+import dev.plant.backend.domain.user.exception.NotFoundUserException;
 import dev.plant.backend.domain.user.repository.UserRepository;
+import dev.plant.backend.global.ErrorCode;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 import java.util.Optional;
 
@@ -44,11 +47,13 @@ public class UserService {
 
         return new LoginResponseDto(isNewUser, nickname, profileImageUrl, accountBalance);
     }
-    @Transactional
     //회원 탈퇴
+    @Transactional
     public void withdraw(HttpSession session){
+
         String accessToken = (String) session.getAttribute("accessToken");
-        Long kakaoId = (Long) session.getAttribute("kakaoId");
+        Long kakaoId = getKakaoId(session);
+
         if (accessToken != null){
             kakaoService.unlinkKakaoAccount(accessToken);
         }
@@ -56,6 +61,32 @@ public class UserService {
         userRepository.deleteByKakaoId(kakaoId);
 
         session.invalidate();
-
     }
+    //계좌 잔액 수정 및 입력
+    @Transactional
+    public UserBalanceResponse changeAccountBalance(HttpSession session, UserBalanceRequest userBalanceRequest){
+
+        Long kakaoId = getKakaoId(session);
+        User user = getUser(kakaoId);
+
+        Integer accountBalance = user.getAccountBalance();
+
+        if(!userBalanceRequest.getAccountBalance().equals(accountBalance)) { //기존 값과 다르면 새로운 값 저장
+            user.updateAccountBalance(userBalanceRequest.getAccountBalance());
+        }
+        return new UserBalanceResponse(user.getAccountBalance());
+    }
+
+    //Kakao ID Get
+    public long getKakaoId(HttpSession session){
+        Long kakaoId = (Long) session.getAttribute("kakaoId");
+        return kakaoId;
+    }
+    //user Get
+    public User getUser(Long kakaoId){
+        User user = userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+        return user;
+    }
+
 }

--- a/src/main/java/dev/plant/backend/global/ErrorCode.java
+++ b/src/main/java/dev/plant/backend/global/ErrorCode.java
@@ -5,10 +5,13 @@ import lombok.*;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+
     INTERNAL_SERVER_ERROR("정의되지 않은 에러가 발생했습니다.", 500),
     BAD_REQUEST("잘못된 요청입니다.", 400),
     NOT_FOUND_RESOURCE("존재하지 않는 리소스입니다.", 404),
-    CONFLICT_ERROR("중복된 값입니다.", 409);
+    CONFLICT_ERROR("중복된 값입니다.", 409),
+    //User
+    NOT_FOUND_USER("사용자를 찾을 수 없습니다", 404);
 
     private final String message;
     private final int status;

--- a/src/main/java/dev/plant/backend/global/GlobalExceptionHandler.java
+++ b/src/main/java/dev/plant/backend/global/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package dev.plant.backend.global;
 
+import dev.plant.backend.domain.user.exception.NotFoundUserException;
 import dev.plant.backend.global.exception.ApiException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
@@ -22,6 +23,12 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = ErrorResponse.of(exception.getErrorCode());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
-
+    //Not Found
+    @ExceptionHandler(NotFoundUserException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundUser(NotFoundUserException exception) {
+        log.error("handleNotFound", exception);
+        ErrorResponse errorResponse = ErrorResponse.of(exception.getErrorCode());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
 
 }

--- a/src/main/java/dev/plant/backend/global/exception/BusinessException.java
+++ b/src/main/java/dev/plant/backend/global/exception/BusinessException.java
@@ -1,0 +1,13 @@
+package dev.plant.backend.global.exception;
+
+import dev.plant.backend.global.ErrorCode;
+
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+    public BusinessException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/dev/plant/backend/global/response/ApiResponse.java
+++ b/src/main/java/dev/plant/backend/global/response/ApiResponse.java
@@ -19,8 +19,8 @@ public class ApiResponse<T> {
         return new ApiResponse<>(status, message, data);
     }
 
-    public static <T> ApiResponse<T> ok(T data) {
-        return new ApiResponse<>(200, "요청이 성공적으로 처리되었습니다.", data);
+    public static <T> ApiResponse<T> ok(String message, T data) {
+        return new ApiResponse<>(200,message , data);
     }
 
 }


### PR DESCRIPTION
## 회원 계좌 정보 수정 및 입력 기능 구현

###  개요
- 회원의 계좌 잔액 정보를 최초 등록 및 이후 수정할 수 있는 기능을 구현
- 최초 로그인 시 계좌 잔액을 입력받고, 이후에는 기존 잔액을 수정 가능

### 구현 내용

#### 1. 계좌 잔액 입력 처리
- 최초 로그인한 사용자라면, 모달을 통해 계좌 잔액 입력
- 입력된 잔액은 `User` 엔티티의 `accountBalance` 필드에 저장
- 입력값이 없을 경우 기본값 `0`으로 처리
- 저장 후 `ApiResponse` 형태로 잔액 정보 반환

#### 2. 계좌 잔액 수정 처리
- 로그인한 사용자가 기존 계좌 잔액을 변경 요청할 경우
- 동일한 값이 아닌 경우에만 DB 업데이트 수행

#### 3. API 응답 처리 통일
- `ApiResponse` 포맷으로 성공 메시지 및 상태코드 제공

```json
{
  "status": 200,
  "message": "총 잔액이 성공적으로 설정되었습니다.",
  "data": {
    "accountBalance": 100000
  }
}