### PR TITLE
#9 [Feat] 사용자별 수입 및 지출 내역 조회 기능 구현

### DIFF
--- a/src/main/java/dev/plant/backend/domain/transaction/controller/TransactionController.java
+++ b/src/main/java/dev/plant/backend/domain/transaction/controller/TransactionController.java
@@ -1,0 +1,92 @@
+package dev.plant.backend.domain.transaction.controller;
+
+import dev.plant.backend.domain.transaction.dto.DailyRecordResponse;
+import dev.plant.backend.domain.transaction.dto.MonthlyRecordResponse;
+import dev.plant.backend.domain.transaction.service.TransactionService;
+import dev.plant.backend.domain.user.domain.User;
+import dev.plant.backend.domain.user.repository.UserRepository;
+import dev.plant.backend.global.response.ApiResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/records", produces = "application/json; charset=UTF8")
+public class TransactionController {
+
+    private final TransactionService transactionService;
+    private final UserRepository userRepository;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<MonthlyRecordResponse>> getMonthlyRecords(
+            @RequestParam(required = false) String date,
+            HttpSession session
+    ) {
+        Long kakaoId = (Long) session.getAttribute("kakaoId");
+        if (kakaoId == null) {
+            return ResponseEntity.status(401).body(ApiResponse.of(401, "로그인이 필요합니다.", null));
+        }
+
+        User user = userRepository.findByKakaoId(kakaoId).orElse(null);
+        if (user == null) {
+            return ResponseEntity.status(404).body(ApiResponse.of(404, "사용자를 찾을 수 없습니다.", null));
+        }
+
+        Long userId = user.getId();
+
+        YearMonth targetMonth;
+        try {
+            targetMonth = (date == null || date.isEmpty())
+                    ? YearMonth.now()
+                    : YearMonth.parse(date, DateTimeFormatter.ofPattern("yyyy-MM"));
+        } catch (Exception e) {
+            targetMonth = YearMonth.now();
+        }
+
+        MonthlyRecordResponse response = transactionService.getMonthlyRecords(userId, targetMonth);
+        return ResponseEntity.ok(ApiResponse.of(200, "수입/지출 조회가 완료되었습니다", response));
+    }
+
+    @GetMapping(params = "date")
+    public ResponseEntity<ApiResponse<?>> getRecordsByDate(
+            @RequestParam String date,
+            HttpSession session
+    ) {
+        Long kakaoId = (Long) session.getAttribute("kakaoId");
+        if (kakaoId == null) {
+            return ResponseEntity.status(401).body(ApiResponse.of(401, "로그인이 필요합니다.", null));
+        }
+
+        User user = userRepository.findByKakaoId(kakaoId).orElse(null);
+        if (user == null) {
+            return ResponseEntity.status(404).body(ApiResponse.of(404, "사용자를 찾을 수 없습니다.", null));
+        }
+
+        Long userId = user.getId();
+
+        try {
+            if (date.matches("^\\d{4}-\\d{2}$")) {
+                // yyyy-MM → 월별 조회
+                YearMonth yearMonth = YearMonth.parse(date, DateTimeFormatter.ofPattern("yyyy-MM"));
+                MonthlyRecordResponse response = transactionService.getMonthlyRecords(userId, yearMonth);
+                return ResponseEntity.ok(ApiResponse.of(200, "월별 수입/지출 조회가 완료되었습니다", response));
+            } else if (date.matches("^\\d{4}-\\d{2}-\\d{2}$")) {
+                // yyyy-MM-dd → 일별 조회
+                LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                DailyRecordResponse response = transactionService.getDailyRecords(userId, localDate);
+                return ResponseEntity.ok(ApiResponse.of(200, "일별 수입/지출 조회가 완료되었습니다", response));
+            } else {
+                return ResponseEntity.badRequest().body(ApiResponse.of(400, "날짜 형식이 잘못되었습니다 (yyyy-MM 또는 yyyy-MM-dd)", null));
+            }
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(ApiResponse.of(500, "서버 에러가 발생했습니다", null));
+        }
+    }
+
+}

--- a/src/main/java/dev/plant/backend/domain/transaction/dto/DailyRecordResponse.java
+++ b/src/main/java/dev/plant/backend/domain/transaction/dto/DailyRecordResponse.java
@@ -1,0 +1,18 @@
+package dev.plant.backend.domain.transaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DailyRecordResponse {
+
+    private Long date; // 유닉스 타임스탬프 (년월일)
+    private Integer totalBalance;
+    private List<RecordDetailDto> dailyRecords;
+
+}

--- a/src/main/java/dev/plant/backend/domain/transaction/dto/MonthlyRecordResponse.java
+++ b/src/main/java/dev/plant/backend/domain/transaction/dto/MonthlyRecordResponse.java
@@ -1,0 +1,19 @@
+package dev.plant.backend.domain.transaction.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MonthlyRecordResponse {
+
+    private Long yearMonth; // 유닉스 타임스탬프 (년월)
+    private Integer totalBalance;
+    private List<RecordDetailDto> monthlyRecords;
+
+}

--- a/src/main/java/dev/plant/backend/domain/transaction/dto/RecordDetailDto.java
+++ b/src/main/java/dev/plant/backend/domain/transaction/dto/RecordDetailDto.java
@@ -1,0 +1,19 @@
+package dev.plant.backend.domain.transaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RecordDetailDto {
+
+    private Long id;
+    private String type;
+    private Integer amount;
+    private String category;
+    private String memo;
+    private Long date; // 유닉스 타임스탬프
+
+}

--- a/src/main/java/dev/plant/backend/domain/transaction/repository/TransactionRepository.java
+++ b/src/main/java/dev/plant/backend/domain/transaction/repository/TransactionRepository.java
@@ -1,0 +1,46 @@
+package dev.plant.backend.domain.transaction.repository;
+
+import dev.plant.backend.domain.transaction.domain.Transaction;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TransactionRepository {
+
+    private final EntityManager em;
+
+    public List<Transaction> findByMonth(Long userId, YearMonth yearMonth) {
+        long start = yearMonth.atDay(1).atStartOfDay().toEpochSecond(ZoneOffset.UTC);
+        long end = yearMonth.atEndOfMonth().atStartOfDay().toEpochSecond(ZoneOffset.UTC);
+
+        return em.createQuery("""
+                SELECT t FROM Transaction t
+                WHERE t.user.id = :userId AND t.date BETWEEN :start AND :end
+                """, Transaction.class)
+                .setParameter("userId", userId)
+                .setParameter("start", start)
+                .setParameter("end", end)
+                .getResultList();
+    }
+
+    public List<Transaction> findByDate(Long userId, LocalDate date) {
+        long startOfDay = date.atStartOfDay().toEpochSecond(ZoneOffset.UTC);
+        long endOfDay = date.plusDays(1).atStartOfDay().toEpochSecond(ZoneOffset.UTC) - 1;
+
+        return em.createQuery("""
+                SELECT t FROM Transaction t
+                WHERE t.user.id = :userId AND t.date BETWEEN :start AND :end
+                """, Transaction.class)
+                .setParameter("userId", userId)
+                .setParameter("start", startOfDay)
+                .setParameter("end", endOfDay)
+                .getResultList();
+    }
+}

--- a/src/main/java/dev/plant/backend/domain/transaction/service/TransactionService.java
+++ b/src/main/java/dev/plant/backend/domain/transaction/service/TransactionService.java
@@ -1,0 +1,80 @@
+package dev.plant.backend.domain.transaction.service;
+
+import dev.plant.backend.domain.transaction.domain.Transaction;
+import dev.plant.backend.domain.transaction.dto.DailyRecordResponse;
+import dev.plant.backend.domain.transaction.dto.MonthlyRecordResponse;
+import dev.plant.backend.domain.transaction.dto.RecordDetailDto;
+import dev.plant.backend.domain.transaction.model.Type;
+import dev.plant.backend.domain.transaction.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TransactionService {
+
+    private final TransactionRepository transactionRepository;
+
+    @Transactional(readOnly = true)
+    public MonthlyRecordResponse getMonthlyRecords(Long userId, YearMonth yearMonth) {
+        List<Transaction> transactions = transactionRepository.findByMonth(userId, yearMonth);
+
+        int totalBalance = transactions.stream()
+                .mapToInt(t -> t.getType() == Type.INCOME ? t.getAmount() : -t.getAmount())
+                .sum();
+
+        List<RecordDetailDto> recordDtos = transactions.stream()
+                .map(t -> RecordDetailDto.builder()
+                        .id(t.getId())
+                        .type(t.getType().name())
+                        .amount(t.getAmount())
+                        .category(t.getCategory().name())
+                        .memo(t.getMemo())
+                        .date(t.getDate())
+                        .build())
+                .toList();
+
+        return MonthlyRecordResponse.builder()
+                .yearMonth(
+                        yearMonth.atDay(1)
+                                .atStartOfDay()
+                                .toEpochSecond(ZoneOffset.UTC)
+                )
+                .totalBalance(totalBalance)
+                .monthlyRecords(recordDtos)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public DailyRecordResponse getDailyRecords(Long userId, LocalDate date) {
+        List<Transaction> transactions = transactionRepository.findByDate(userId, date);
+
+        int totalBalance = transactions.stream()
+                .mapToInt(t -> t.getType() == Type.INCOME ? t.getAmount() : -t.getAmount())
+                .sum();
+
+        List<RecordDetailDto> recordDtos = transactions.stream()
+                .map(t -> RecordDetailDto.builder()
+                        .id(t.getId())
+                        .type(t.getType().name())
+                        .amount(t.getAmount())
+                        .category(t.getCategory().name())
+                        .memo(t.getMemo())
+                        .date(t.getDate())
+                        .build())
+                .toList();
+
+        return DailyRecordResponse.builder()
+                .date(date.atStartOfDay().toEpochSecond(ZoneOffset.UTC)) // 유닉스 타임스탬프
+                .totalBalance(totalBalance)
+                .dailyRecords(recordDtos)
+                .build();
+    }
+}


### PR DESCRIPTION
### 사용자별 수입 및 지출 내역 조회 기능 구현

- 월별/일별 수입·지출 조회 API 구현
- 날짜 형식에 따라 자동으로 월/일 조회 분기
- DTO 분리 (MonthlyRecordResponse, DailyRecordResponse)
- 세션에서 kakaoId 꺼내 유저 식별

Postman으로 테스트 후 Notion에 스크린샷 첨부 해놨습니다